### PR TITLE
Change github action trigger

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -1,8 +1,6 @@
 name: PHP Composer
 
 on:
-  push:
-    branches: [ master, dev ]
   pull_request:
     branches: [ master, dev ]
 


### PR DESCRIPTION
It used to be doing the testing twice when requesting pull request. The
first one is on the push and the second one is on the pull_request. This
behavior is changed to save build-time resource.