### PR TITLE
fix(action): auto PR workflow sometimes showing invalid PR

### DIFF
--- a/.github/workflows/pr-on-pr.yml
+++ b/.github/workflows/pr-on-pr.yml
@@ -32,7 +32,9 @@ jobs:
               title: res.data.title,
               body: res.data.body,
               head: res.data.head.ref,
+              headLabel: res.data.head.label,
               base: res.data.base.ref,
+              baseLabel: res.data.base.label,
               etc: res,
               labels,
             }
@@ -57,7 +59,7 @@ jobs:
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 state: "open",
-                head: prInfo.head,
+                head: prInfo.headLabel,
                 base: "${{ env.AUTO_PR_BRANCH }}",
               });
 


### PR DESCRIPTION
It cased by the head in pull list make us to add user/org name before the repo name.

ref: https://docs.github.com/en/rest/pulls/pulls?apiVersion=2022-11-28#list-pull-requests